### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ It must contain:
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ### Actions
 
 * get_task_results - Given an execution id, this action gets results for all the tasks for that execution.

--- a/actions/get_task_results.yaml
+++ b/actions/get_task_results.yaml
@@ -1,7 +1,7 @@
 ---
   name: "get_task_results"
   pack: "mistral"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Get results of mistral task in an execution."
   enabled: true
   entry_point: "get_results/get_task_results.py"

--- a/actions/get_workbook_definition.yaml
+++ b/actions/get_workbook_definition.yaml
@@ -1,7 +1,7 @@
 ---
   name: "get_workbook_definition"
   pack: "mistral"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Get the definition of the mistral workbook."
   enabled: true
   entry_point: "get_workbook_definition.py"

--- a/actions/get_workflow_results.yaml
+++ b/actions/get_workflow_results.yaml
@@ -1,7 +1,7 @@
 ---
   name: "get_workflow_results"
   pack: "mistral"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Get results of mistral workflow."
   enabled: true
   entry_point: "get_results/get_workflow_results.py"

--- a/actions/kill_workflow.yaml
+++ b/actions/kill_workflow.yaml
@@ -1,7 +1,7 @@
 ---
   name: "kill_workflow"
   pack: "mistral"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Kill a running mistral workflow."
   enabled: true
   entry_point: "kill_workflow.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ description: Mistral integrations to operate mistral.
 keywords:
   - mistral
   - workflows
-version: 0.2.0
+version: 0.3.0
 author: StackStorm
 email: support@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.